### PR TITLE
Improve Less size mixins 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ _/
 
 # Mac poops
 .DS_Store
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ _/
 # Mac poops
 .DS_Store
 
+# intellij config
 .idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/style/mixins.less
+++ b/style/mixins.less
@@ -133,6 +133,13 @@
 
 /**
  * Set width and height on en element
+ * If only one value parameter is set, width and height will be equal
+ * ex:
+ * 		.size(10px);
+ *
+ * return:
+ *		width: 10px;
+ *		height: 10px;
  */
 .size (@width:auto; @height:@width)
 {
@@ -160,6 +167,13 @@
 
 /**
  * Set min-width and min-height
+ * If only one value parameter is set, min-width and min-height will be equal
+ * ex:
+ * 		.size(10px);
+ *
+ * return:
+ *		min-width: 10px;
+ *		min-height: 10px;
  */
 .minSize (@width: none, @height:@width)
 {
@@ -169,6 +183,13 @@
 
 /**
  * Set max-width and max-height
+ * If only one value parameter is set, max-width and max-height will be equal
+ * ex:
+ * 		.size(10px);
+ *
+ * return:
+ *		max-width: 10px;
+ *		max-height: 10px;
  */
 .maxSize (@width: none, @height:@width)
 {

--- a/style/mixins.less
+++ b/style/mixins.less
@@ -134,7 +134,7 @@
 /**
  * Set width and height on en element
  */
-.size (@width:auto; @height:auto)
+.size (@width:auto; @height:@width)
 {
 	width: @width;
 	height: @height;
@@ -161,7 +161,7 @@
 /**
  * Set min-width and min-height
  */
-.minSize (@width: none, @height: none)
+.minSize (@width: none, @height:@width)
 {
 	min-width: @width;
 	min-height: @height;
@@ -170,7 +170,7 @@
 /**
  * Set max-width and max-height
  */
-.maxSize (@width: none, @height: none)
+.maxSize (@width: none, @height:@width)
 {
 	max-width: @width;
 	max-height: @height;


### PR DESCRIPTION
Replacement of `@height:auto` by `@height:@width` on mixins parameter `.size()`, `.minSize()`, and `.maxSize()`.